### PR TITLE
Add GPU VRAM, update units to MiB, GiB & TiB

### DIFF
--- a/src/components/AppPlatformSizes.vue
+++ b/src/components/AppPlatformSizes.vue
@@ -58,7 +58,7 @@
           </b-table-column>
 
           <b-table-column field="memory_bytes" label="Memory" sortable>
-              {{ (props.row.memory_bytes / (1024 * 1024 * 1024)).toFixed(1) }} GB
+              {{ (props.row.memory_bytes / (1024 * 1024 * 1024)).toFixed(1) }} GiB
           </b-table-column>
 
           <b-table-column field="bandwidth_allowance_gib" label="Bandwidth" sortable>

--- a/src/components/GpuSizes.vue
+++ b/src/components/GpuSizes.vue
@@ -50,6 +50,10 @@
               {{ props.row.gpu_info ? props.row.gpu_info.count : '-' }}
           </b-table-column>
 
+          <b-table-column field="gpu_vram" label="VRAM" sortable>
+              {{ props.row.gpu_info && props.row.gpu_info.vram ? `${props.row.gpu_info.vram.amount} ${props.row.gpu_info.vram.unit.toUpperCase()}` : '-' }}
+          </b-table-column>
+
           <b-table-column field="gpu_model" label="GPU Type" sortable>
               {{ props.row.gpu_info ? props.row.gpu_info.model : '-' }}
           </b-table-column>

--- a/src/components/GpuSizes.vue
+++ b/src/components/GpuSizes.vue
@@ -31,7 +31,7 @@
           </b-table-column>
 
           <b-table-column field="memory" label="RAM" sortable>
-              {{ props.row.memory | mbToGb }} GB
+              {{ props.row.memory | mbToGb }} GiB
           </b-table-column>
 
           <b-table-column field="vcpus" label="CPU" sortable>
@@ -39,7 +39,7 @@
           </b-table-column>
 
           <b-table-column field="disk" label="Disk" sortable>
-              {{ props.row.disk }} GB
+              {{ props.row.disk }} GiB
           </b-table-column>
 
           <b-table-column field="scratch_disk" label="Scratch Disk" sortable>
@@ -51,7 +51,7 @@
           </b-table-column>
 
           <b-table-column field="gpu_vram" label="VRAM" sortable>
-              {{ props.row.gpu_info && props.row.gpu_info.vram ? `${props.row.gpu_info.vram.amount} ${props.row.gpu_info.vram.unit.toUpperCase()}` : '-' }}
+              {{ props.row.gpu_info && props.row.gpu_info.vram ? `${props.row.gpu_info.vram.amount} ${formatVramUnit(props.row.gpu_info.vram.unit)}` : '-' }}
           </b-table-column>
 
           <b-table-column field="gpu_model" label="GPU Type" sortable>
@@ -59,7 +59,7 @@
           </b-table-column>
 
           <b-table-column field="transfer" label="Transfer" sortable>
-              {{ props.row.transfer }} TB
+              {{ props.row.transfer }} TiB
           </b-table-column>
 
           <b-table-column field="price_monthly" label="Price Monthly" sortable>
@@ -150,7 +150,39 @@ export default {
       const scratchDisk = row.disk_info.find(disk => disk.type === 'scratch')
       if (!scratchDisk || !scratchDisk.size) return '-'
 
-      return `${scratchDisk.size.amount} ${scratchDisk.size.unit.toUpperCase()}`
+      // Convert unit if needed
+      const unit = this.formatDiskUnit(scratchDisk.size.unit)
+      return `${scratchDisk.size.amount} ${unit}`
+    },
+    formatDiskUnit (unit) {
+      if (!unit) return ''
+      // Convert decimal units to binary units
+      const unitMap = {
+        'gb': 'GiB',
+        'mb': 'MiB',
+        'tb': 'TiB',
+        'kb': 'KiB',
+        'gib': 'GiB',
+        'mib': 'MiB',
+        'tib': 'TiB',
+        'kib': 'KiB'
+      }
+      return unitMap[unit.toLowerCase()] || unit.toUpperCase()
+    },
+    formatVramUnit (unit) {
+      if (!unit) return ''
+      // Convert decimal units to binary units
+      const unitMap = {
+        'gb': 'GiB',
+        'mb': 'MiB',
+        'tb': 'TiB',
+        'kb': 'KiB',
+        'gib': 'GiB',
+        'mib': 'MiB',
+        'tib': 'TiB',
+        'kib': 'KiB'
+      }
+      return unitMap[unit.toLowerCase()] || unit.toUpperCase()
     }
   },
   created () {

--- a/src/components/Sizes.vue
+++ b/src/components/Sizes.vue
@@ -31,7 +31,7 @@
           </b-table-column>
 
           <b-table-column field="memory" label="RAM" sortable>
-              {{ props.row.memory | mbToGb }} GB
+              {{ props.row.memory | mbToGb }} GiB
           </b-table-column>
 
           <b-table-column field="vcpus" label="CPU" sortable>
@@ -39,11 +39,11 @@
           </b-table-column>
 
           <b-table-column field="disk" label="Disk" sortable>
-              {{ props.row.disk }} GB
+              {{ props.row.disk }} GiB
           </b-table-column>
 
           <b-table-column field="transfer" label="Transfer" sortable>
-              {{ props.row.transfer }} TB
+              {{ props.row.transfer }} TiB
           </b-table-column>
 
           <b-table-column field="price_monthly" label="Price Monthly" sortable>


### PR DESCRIPTION
👋 Hey

Just a few small things.

1. Adds a VRAM column to GPU sizes.
2. Update units to MiB, GiB & TiB instead of MB, GB & TB.

See it in action [here](https://do-api-slugs-ecqyq.ondigitalocean.app/).

Cheers!